### PR TITLE
Security fix for file uploads

### DIFF
--- a/backup/setupWin.py
+++ b/backup/setupWin.py
@@ -318,9 +318,10 @@ def uploadFile(var):
         files = request.files.getlist('files[]') 
         fileNo=0
         for file in files:
+            file.filename = secure_filename(file.filename) # ensure file name is secure
             fupload = os.path.join(fPath,file.filename)
 
-            if secure_filename(file.filename) and not os.path.exists(fupload):
+            if not os.path.exists(fupload):
                 try:
                     file.save(fupload)    
                     print(file.filename + ' Uploaded')

--- a/build/setup.py
+++ b/build/setup.py
@@ -14,7 +14,7 @@ excludes = []
 
 setup(
 name = 'WiFile',
-version = '1',
+version = '1.1',
 description = 'File explorer over wifi',
 author = 'Rehan Ahmed',
 author_email = 'rhnahdshk@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -481,8 +481,9 @@ def uploadFile(var=""):
         files = request.files.getlist('files[]')
         fileNo = 0
         for file in files:
+            file.filename = secure_filename(file.filename) # ensure file name is secure
             fupload = os.path.join(fPath, file.filename)
-            if secure_filename(file.filename) and not os.path.exists(fupload):
+            if not os.path.exists(fupload):
                 try:
                     file.save(fupload)
                     print(file.filename + ' Uploaded')


### PR DESCRIPTION
Sets `file.filename` to `secure_filename(file.filename)` to ensure file name is always secure for file uploads.

Previous usage did not use secure_filename correctly.

See: [https://werkzeug.palletsprojects.com/en/2.3.x/utils/#werkzeug.utils.secure_filename](https://werkzeug.palletsprojects.com/en/2.3.x/utils/#werkzeug.utils.secure_filename)

Also updated version to 1.1 in order to track security fix release.